### PR TITLE
allow sorting by 'm'; include meminfo in cpio archive by default

### DIFF
--- a/procs.nim
+++ b/procs.nim
@@ -1338,6 +1338,7 @@ cAdd('<', {pfi_rch}            , cmp, uint64  ): p.rch # ,pfi_rbl + p.rbl
 cAdd('>', {pfi_wch}            , cmp, uint64  ): p.wch # ,pfi_wbl + p.wbl
 cAdd('O', {pfo_score}          , cmp, cint    ): p.oom_score
 cAdd('M', {pfsr_pss}           , cmp, uint64  ): p.pss
+cAdd('m', {pf_rss}             , cmp, culong  ): p.rss # alias for 'R'
 cAdd('l', {}             , cmp, string): cg.labels.getOrDefault(p.spid).join ":"
 let cmpD = cmpOf['D'].cmp; let cmpA = cmpOf['A'].cmp
 

--- a/util/parc.sh
+++ b/util/parc.sh
@@ -5,7 +5,7 @@ set -e
 : "${prog:=s / r /stat r /cmdline R /exe r /io r /schedstat r /smaps_rollup}"
 export t="/dev/shm"     # Meant as a starting point; mktemp -d, trap etc
 # Eg. github.com/c-blake/bu/blob/main/doc/funnel.md#example-xargs-wrapper-script
-export PARC_PATHS="sys/kernel/pid_max uptime" prog
+export PARC_PATHS="sys/kernel/pid_max uptime meminfo" prog
 cd /proc || exit 2
 set [1-9]*              # Just to count procs to divide by j
 echo $* | xargs --process-slot-var=J -n "$((1+$#/j))" -P "$j" \

--- a/util/parc.zsh
+++ b/util/parc.zsh
@@ -13,7 +13,7 @@ for ((i=1; i<=j; i++)); do # Fire $j batches
 # `procs display` style drives specific list needed here.  To show MyStyle needs
 # `PFA=/tmp/x pd -sMyStyle; cpio -tv</tmp/x|tail`, but NOTE unreadable entries
 # (eg. kthread /exe, otherUser /smaps_rollup) are dropped from the cpio archive.
-    [[ $i = 1 ]] && export PARC_PATHS="sys/kernel/pid_max uptime"
+    [[ $i = 1 ]] && export PARC_PATHS="sys/kernel/pid_max uptime meminfo"
     parc s /   r /stat      r /cmdline      R /exe \
          r /io r /schedstat r /smaps_rollup $slice > $t/pfs.$$.$i &
     unset PARC_PATHS


### PR DESCRIPTION
Currently, 'm' (%MEM) works in the format spec, but not in the sort spec.  It's really the same as 'R', but it's nice to be able to use the same letter for both format and sort.  This PR adds 'm' as an alias for 'R'.  It also includes meminfo in the parc scripts, which is required for %MEM.