### PR TITLE
add frqHdr support to display

### DIFF
--- a/configs/kaminsky0/pd.zsh
+++ b/configs/kaminsky0/pd.zsh
@@ -10,6 +10,9 @@ function pd() {
     local input
     declare -a flags
 
+    # repeat header if stdout is a terminal
+    [[ -t 1 ]] && flags+="--frqHdr=-$[${LINES}-3]"
+
     for arg in "$@"; do
         if [[ ${arg:0:1} == "-" ]]; then
             flags+=$arg
@@ -104,7 +107,7 @@ function pd() {
 
         #start_time=$EPOCHREALTIME
 
-        command pd -s user --na "" "${arglist[@]}" "${flags[@]}" "${pids[@]}"
+        command pd -s user "${arglist[@]}" "${flags[@]}" "${pids[@]}"
 
         #echo $[EPOCHREALTIME-start_time]
 
@@ -142,7 +145,7 @@ function pd() {
         fi
 
         #start_time=$EPOCHREALTIME
-        command pd -s user --na "" --format\^="@@%l@@" -W=$[COLUMNS+34] ${arglist[@]} "${flags[@]}" "${pids[@]}" | \
+        command pd -s user --format\^="@@%l@@" -W=$[COLUMNS+34] ${arglist[@]} "${flags[@]}" "${pids[@]}" | \
             sed -E \
                 -e "/^@@.*explicit:.*@@|@@LABELS.*@@/I! s/\x1b\[(..|039|38;2;[0-9]+;[0-9]+;0|)m//g" \
                 -e "/^@@.*explicit:.*@@|@@LABELS.*@@/I! s/.*/\x1b[38:5:242m&\x1b[m/g" \


### PR DESCRIPTION
Sometimes I forget which columns I have chosen to display, and I don't want to scroll up to see the Header line.
This comment adds an `-fqrHdr` option to "display" similar to "scrollsy".

A typical usage would be:
```bash
$ pd -suser --frqHdr=$LINES
```
or, if you want there to be a Header at the top of your terminal when the output is finished, you can use a negative number to make it count from the end:
```bash
$ pd -suser --frqHdr=-$LINES
```

There might be some corner cases that need addressing, particularly with respect to rollups/merges, where I'm seeing some inconsistent behavior, e.g., my pd() shell function with `pd-rollups` support needs an offset.  So...maybe it's more of a proof of concept.  Happy to discuss a different UI, etc.