### PR TITLE
move the "add final header" feature out of procs.nim to an awk script

### DIFF
--- a/configs/kaminsky0/add-final-header.awk
+++ b/configs/kaminsky0/add-final-header.awk
@@ -1,0 +1,36 @@
+#!/usr/bin/awk -f
+
+# This script copies its input to its output, like cat, with one
+# addition:  It assumes that the first line of the input is a header,
+# which it repeats (inserts) n lines from the end of the output. The
+# motivation is that sometimes you want to "cat" a file or display
+# program's output that contains tabular data, but you don't want to
+# have to scroll back the terminal to see the column headers.
+#
+# EXAMPLE USAGE:
+#   $ ps axuw | add-final-header.awk $(($LINES - 3))
+#   $ lsof -nu kaminsky | add-final-header.awk $(($LINES - 3))
+
+# Check if n is provided as an argument
+BEGIN {
+    if (ARGC < 2) {
+        print "Usage: add-final-header.awk n"
+        exit 1
+    }
+    n = ARGV[1]
+    delete ARGV[1]  # Remove n from ARGV to avoid processing it as input
+}
+
+# Count the total number of lines
+{ lines[count++] = $0 }
+
+# At the end of the input, print all lines
+END {
+    for (i = 0; i < count; i++) {
+        print lines[i]
+        # Print the first line n lines from the end
+        if (i == count - n) {
+            print lines[0]
+        }
+    }
+}

--- a/configs/kaminsky0/color
+++ b/configs/kaminsky0/color
@@ -7,7 +7,7 @@
 color = "kern:0x0:0      underline"     #0x00
 color = "sleep:0x2:0     NONE"          #0x01
 color = "zomb:0x3:0      struck"        #0x02
-color = "stop:0x4:0      blink"         #0x03
+color = "stop:0x4:0      struck"        #0x03
 color = "run:0x5:0       bold"          #0x04
 
 color = "MT:0x6:1        italic"        #0x05
@@ -25,16 +25,16 @@ color = "dmcrypt:0x0:3   WHITE on_blue" #0x0F
 color = "scsi_eh:0x0:3   WHITE on_blue" #0x10
 color = "scsi_tmf:0x0:3  WHITE on_blue" #0x11
 color = "wq:0x0:3        WHITE on_blue" #0x12
-#color = "rcuS:0x0:3      WHITE on_blue" #0x13
-#color = "Xiod:0x0:3      WHITE on_blue" #0x14
+color = "rcuS:0x0:3      WHITE on_blue" #0x13
+color = "Xiod:0x0:3      WHITE on_blue" #0x14
 color = "kdmflush:0x0:3  WHITE on_blue" #0x15
 color = "iprtVBox:0x0:3  WHITE on_blue" #0x16
 color = "nvidia:0x0:3    WHITE on_blue" #0x17
-#color = "erofs:0x0:3     WHITE on_blue" #0x18
-#color = "idle:0x0:3      WHITE on_blue" #0x19
-#color = "crtc:0x0:3      WHITE on_blue" #0x1A
-#color = "bch:0x0:3       WHITE on_blue" #0x1B
-#color = "jbd:0x0:3       WHITE on_blue" #0x1C
+color = "erofs:0x0:3     WHITE on_blue" #0x18
+color = "idle:0x0:3      WHITE on_blue" #0x19
+color = "crtc:0x0:3      WHITE on_blue" #0x1A
+color = "bch:0x0:3       WHITE on_blue" #0x1B
+color = "jbd:0x0:3       WHITE on_blue" #0x1C
 
 color = "root:0x1:3      fhue5"         #0x20
 

--- a/procs.nim
+++ b/procs.nim
@@ -1074,7 +1074,6 @@ type
     indent*, width*: int                                    ##termWidth override
     delay*: Timespec
     eqLeaf*, blanks*, wide*, binary*, plain*, header*, realIds*, schedSt*: bool
-    frqHdr*: int                                            #header frq
     pids*: seq[string]                                      ##pids to display
     t0: Timespec                                            #ref time for pTms
     kinds: seq[Kind]                                        #kinds user colors
@@ -1781,29 +1780,13 @@ proc display*(cf: var DpCf) = # free letters: N W Y k
     procs = procs2
   if cf.delay >= ts0:
     for p in procs: last[p.pid] = p
-  # Write the header every `frqHdr` lines.  If `frqHdr` is negative,
-  # count from the end, so that you end up with a header at the top
-  # of the last page of the output.
-  var idx = 0
-  if cf.frqHdr < 0:
-    cf.frqHdr = 1-cf.frqHdr
-    idx = (procs.len mod cf.frqHdr) + (procs.len div cf.frqHdr)
-    idx = cf.frqHdr - idx
   if cf.cmps.len > 0:
     var ptrs = newSeq[ptr Proc](procs.len)
     for i in 0 ..< procs.len: ptrs[i] = procs[i].addr
     ptrs.sort(multiLevelCmp)
-    for pp in ptrs:
-      if cf.header and cf.frqHdr != 0 and idx > 0 and idx mod cf.frqHdr == 0:
-        cf.hdrWrite
-      idx.inc
-      cf.fmtWrite pp[], 0
+    for pp in ptrs: cf.fmtWrite pp[], 0
   else:
-    for p in procs:
-      if cf.header and cf.frqHdr != 0 and idx > 0 and idx mod cf.frqHdr == 0:
-        cf.hdrWrite
-      idx.inc
-      cf.fmtWrite p.unsafeAddr[], 0
+    for p in procs: cf.fmtWrite p.unsafeAddr[], 0
   if cf.delay < ts0: return
   let dJiffies = cf.delay.tv_sec.int*100 + (cf.delay.tv_nsec.int div 10_000_000)
   var zero: Proc
@@ -2371,7 +2354,6 @@ ATTR=attr specs as in --version output""", # Uglier: ATTR=""" & textAttrHelp,
                "wide"   : "%C does not truncate to terminal width",
                "plain"  : "plain text; aka no color Esc sequences",
                "header" : "add row at start of data with col names",
-               "frqHdr":  "frequency of header repeats",
                "indent" : "per-level depth-indentation",
                "width"  : "override auto-detected terminal width",
                "delay"  : "seconds between differential reports",


### PR DESCRIPTION
This PR reverts the the changes to `procs.nim` that added a `--frqHdr` option to the display command.

Instead, users can add the repeated header via a more generic awk script (see comment in the script for examples).  Also, update the `kaminsky0` config files such that the `pd()` shell function invokes the awk script by default if stdout is a terminal.

See #10 for further discussion.

Also added some color to the header (via the shell function).  Example screenshot:

![image](https://github.com/user-attachments/assets/9dadb482-9a99-43f1-aabc-b1063cee7fa0)
